### PR TITLE
Remove unnecessary loop in trigger()

### DIFF
--- a/filter-senderscore.go
+++ b/filter-senderscore.go
@@ -216,13 +216,11 @@ func filterInit() {
 }
 
 func trigger(currentSlice map[string]func(string, string, []string), atoms []string) {
-	for k, v := range currentSlice {
-		if k == atoms[4] {
-			v(atoms[4], atoms[5], atoms[6:])
-			return
-		}
+	if handler, ok := currentSlice[atoms[4]]; ok {
+		handler(atoms[4], atoms[5], atoms[6:])
+	} else {
+		log.Fatalf("invalid phase: %s", atoms[4])
 	}
-	os.Exit(1)
 }
 
 func skipConfig(scanner *bufio.Scanner) {


### PR DESCRIPTION
In commit 9ddc9f8 (Simplify trigger code, 2019-12-14), the trigger() function was simplified by removing an unneeded variable. On second thought, the whole loop seems unnecessary and can be replaced it with a simple dictionary lookup.

While at it, also add a log error message when bailing out on an invalid phase name.