### PR TITLE
Avoid segmentation fault on invalid session ID

### DIFF
--- a/filter-senderscore.go
+++ b/filter-senderscore.go
@@ -112,7 +112,10 @@ func linkDisconnect(phase string, sessionId string, params []string) {
 }
 
 func filterConnect(phase string, sessionId string, params[] string) {
-	s := sessions[sessionId]
+	s, ok := sessions[sessionId]
+	if !ok {
+		log.Fatalf("invalid session ID: %s", sessionId)
+	}
 
 	// no slow factor, neutral or 100% good IP
 	if (*slowFactor == -1 || s.score == -1 || s.score == 100) {
@@ -134,7 +137,11 @@ func dataline(phase string, sessionId string, params[] string) {
 	token := params[0]
 	line := strings.Join(params[1:], "|")
 
-	s := sessions[sessionId]
+	s, ok := sessions[sessionId]
+	if !ok {
+		log.Fatalf("invalid session ID: %s", sessionId)
+	}
+
 	if s.first_line == true {
 		if (s.score != -1 && *scoreHeader) {
 			if version < "0.5" {
@@ -154,7 +161,11 @@ func dataline(phase string, sessionId string, params[] string) {
 }
 
 func delayedAnswer(phase string, sessionId string, params[] string) {
-	s := sessions[sessionId]
+	s, ok := sessions[sessionId]
+	if !ok {
+		log.Fatalf("invalid session ID: %s", sessionId)
+	}
+
 	if (s.score != -1 && s.score < int8(*blockBelow) && *blockPhase == phase) {
 		delayedDisconnect(sessionId, params)
 		return


### PR DESCRIPTION
Passing an invalid session ID to any of the filters currently results in a segmentation fault. While this should never happen in practice, it is better to be safe than sorry.