### PR TITLE
Support IP address whitelists

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ listen on all filter "senderscore"
 
 `-scoreHeader` will add an X-SenderScore header with reputation value if known.
 
+`-whitelist <file>` can be used to specify a file containing a list of IP addresses to whitelist, one per line. IP addresses in that list automatically receive a score of 100.


### PR DESCRIPTION
Add a command line argument that can be used to specify a file that contains a list of IP addresses that automatically receive a score of 100.

Parts of the code are borrowed from filter-greylist.